### PR TITLE
Fix for missing Hotspot Zone

### DIFF
--- a/input/default/k7abd/Digital-Repeaters__Hotspot.csv
+++ b/input/default/k7abd/Digital-Repeaters__Hotspot.csv
@@ -1,2 +1,2 @@
 Zone Name,Comment,Power,RX Freq,TX Freq,Color Code,Asia,AusNZ,BC,Canada,California,ColoradoHD,Europe,India,Massachusetts,N America,Oregon,Oregon TAC,Parrot,Pennsylvania,Reddit,TAC 310,TAC 311,TAC 312,TAC 313,TAC 314,TAC 319,Texas,Unlink,USA,Washington,Worldwide
-Hotspot/BM,Brandmeister,Low,434.45,439.45,1,1,1,1,2,1,2,1,1,1,2,1,2,1,1,1,2,2,2,2,2,2,2,2,2,1,2
+Hotspot/BM;HBM,Brandmeister,Low,434.45,439.45,1,1,1,1,2,1,2,1,1,1,2,1,2,1,1,1,2,2,2,2,2,2,2,2,2,1,2

--- a/input/default/order.json
+++ b/input/default/order.json
@@ -11,12 +11,6 @@
         "expanded": [
         ],
         "exclude_expanded": [
-            "PNWDigital",
-            "Hotspot/BM",
-            "Hillsboro/Analog VHF",
-            "Hillsboro/Analog UHF",
-            "Simplex/Analog VHF",
-            "Simplex/Digital UHF"
         ]
     }
 }


### PR DESCRIPTION
@hillsboro I don't know how I didn't see it earlier... your "Hotspot/BM" zone was on the `exclude_expanded` list, so it was just being explicitly excluded from the generated codeplugs 🤦 

Maybe I'll add some better logging about excluded and empty zones so that it's more obvious when zones are being pruned from the final codeplug.

I also add a codename to your Hotspot/BM zone in the csv file so that the channels and RX list look a bit nicer. This wasn't necessary though.